### PR TITLE
Cleaned up CSS in thargoid-specs.html

### DIFF
--- a/thargoid-specs.css
+++ b/thargoid-specs.css
@@ -1,0 +1,28 @@
+
+th[scope="col"] {
+    background-color:hsl(0, 0%, 30%);
+    border-bottom:3px solid #000000;
+    border-right:1px solid #000000;
+    border-top:1px solid #000000;
+    padding:2px 3px;
+    vertical-align: middle;
+    text-align: center;
+}
+
+th[scope="row"] {
+    background-color:hsl(0, 0%, 30%);
+    border-bottom:1px solid #000000;
+    border-left:1px solid #000000;
+    border-right:1px solid #000000;
+    padding:2px 3px;
+    vertical-align:middle;
+    text-align: center;
+}
+
+td {
+    border-bottom:1px solid #000000;
+    border-right:1px solid #000000;
+    padding:2px 3px;
+    text-align:center;
+    vertical-align:top
+}

--- a/thargoid-specs.css
+++ b/thargoid-specs.css
@@ -1,27 +1,15 @@
-
-th[scope="col"] {
+th {
     background-color: hsl(0, 0%, 30%);
-    border-bottom: 3px solid #000000;
-    border-right: 1px solid #000000;
-    border-top: 1px solid #000000;
+    border: 1px solid #000;
     padding: 2px 3px;
-    vertical-align: middle;
-    text-align: center;
-}
-
-th[scope="row"] {
-    background-color: hsl(0, 0%, 30%);
-    border-bottom: 1px solid #000000;
-    border-left: 1px solid #000000;
-    border-right: 1px solid #000000;
-    padding: 2px 3px;
-    vertical-align: middle;
+    vertical-align: top;
     text-align: center;
 }
 
 td {
-    border-bottom: 1px solid #000000;
-    border-right: 1px solid #000000;
+    /* border-bottom: 1px solid #000000;
+    border-right: 1px solid #000000; */
+    border: 1px solid #000;
     padding: 2px 3px;
     vertical-align: top;
     text-align: center;

--- a/thargoid-specs.css
+++ b/thargoid-specs.css
@@ -1,28 +1,28 @@
 
 th[scope="col"] {
-    background-color:hsl(0, 0%, 30%);
-    border-bottom:3px solid #000000;
-    border-right:1px solid #000000;
-    border-top:1px solid #000000;
-    padding:2px 3px;
+    background-color: hsl(0, 0%, 30%);
+    border-bottom: 3px solid #000000;
+    border-right: 1px solid #000000;
+    border-top: 1px solid #000000;
+    padding: 2px 3px;
     vertical-align: middle;
     text-align: center;
 }
 
 th[scope="row"] {
-    background-color:hsl(0, 0%, 30%);
-    border-bottom:1px solid #000000;
-    border-left:1px solid #000000;
-    border-right:1px solid #000000;
-    padding:2px 3px;
-    vertical-align:middle;
+    background-color: hsl(0, 0%, 30%);
+    border-bottom: 1px solid #000000;
+    border-left: 1px solid #000000;
+    border-right: 1px solid #000000;
+    padding: 2px 3px;
+    vertical-align: middle;
     text-align: center;
 }
 
 td {
-    border-bottom:1px solid #000000;
-    border-right:1px solid #000000;
-    padding:2px 3px;
-    text-align:center;
-    vertical-align:top
+    border-bottom: 1px solid #000000;
+    border-right: 1px solid #000000;
+    padding: 2px 3px;
+    vertical-align: top;
+    text-align: center;
 }

--- a/thargoid-specs.css
+++ b/thargoid-specs.css
@@ -7,8 +7,6 @@ th {
 }
 
 td {
-    /* border-bottom: 1px solid #000000;
-    border-right: 1px solid #000000; */
     border: 1px solid #000;
     padding: 2px 3px;
     vertical-align: top;

--- a/thargoid-specs.html
+++ b/thargoid-specs.html
@@ -10,12 +10,12 @@ dateCreated: 2021-06-15T11:27:45.002Z
 
 <link rel="stylesheet" href="thargoid-specs.css">
 
-
 <h1>Thargoid Specifications</h1>
 <p>Details specifications on the known values of different Thargoid Interceptors and Scouts.</p>
 <p><strong>CAU</strong> = Caustic Damage</p>
 <p><strong>ABS</strong> = Absolute Damage</p>
-<figure class="table">
+
+<figure>
   <table>
     <tbody>
       <tr>
@@ -319,7 +319,7 @@ dateCreated: 2021-06-15T11:27:45.002Z
         </td>
       </tr>
       <tr>
-        <th scope="row"><strong>Heart exertion thresholds<br>In % of current max Hull</></th>
+        <th scope="row"><strong>Heart exertion thresholds<br>In % of current max Hull</style></th>
         <td>N/A</td>
         <td>80</td>
         <td>80</td>

--- a/thargoid-specs.html
+++ b/thargoid-specs.html
@@ -319,7 +319,7 @@ dateCreated: 2021-06-15T11:27:45.002Z
         </td>
       </tr>
       <tr>
-        <th scope="row"><strong>Heart exertion thresholds</strong><br><strong>In % of current max Hull</strong></th>
+        <th scope="row"><strong>Heart exertion thresholds<br>In % of current max Hull</></th>
         <td>N/A</td>
         <td>80</td>
         <td>80</td>

--- a/thargoid-specs.html
+++ b/thargoid-specs.html
@@ -8,314 +8,323 @@ editor: code
 dateCreated: 2021-06-15T11:27:45.002Z
 -->
 
+<link rel="stylesheet" href="thargoid-specs.css">
+
+
 <h1>Thargoid Specifications</h1>
 <p>Details specifications on the known values of different Thargoid Interceptors and Scouts.</p>
+<p><strong>CAU</strong> = Caustic Damage</p>
+<p><strong>ABS</strong> = Absolute Damage</p>
 <figure class="table">
   <table>
     <tbody>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:3px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;border-top:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;                </td>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:3px solid #000000;border-right:1px solid #000000;border-top:1px solid #000000;padding:2px 3px;vertical-align:top;"><strong>Scout</strong>‎‎‎‎‎‎‎‎‎‎  </td>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:3px solid #000000;border-right:1px solid #000000;border-top:1px solid #000000;padding:2px 3px;vertical-align:top;"><strong>Cyclops</strong>     </td>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:3px solid #000000;border-right:1px solid #000000;border-top:1px solid #000000;padding:2px 3px;vertical-align:top;"><strong>Basilisk</strong>       </td>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:3px solid #000000;border-right:1px solid #000000;border-top:1px solid #000000;padding:2px 3px;vertical-align:top;"><strong>Medusa</strong>      </td>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:3px solid #000000;border-right:1px solid #000000;border-top:1px solid #000000;padding:2px 3px;vertical-align:top;"><strong>Hydra</strong>       </td>
+        <th scope="col">&nbsp;                </th>
+        <th scope="col"><strong>Scout</strong>‎‎‎‎‎‎‎‎‎‎</th>
+        <th scope="col"><strong>Cyclops</strong></th></th>
+        <th scope="col"><strong>Basilisk</strong></th>
+        <th scope="col"><strong>Medusa</strong></th>
+        <th scope="col"><strong>Hydra</strong></th>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Number of Hearts</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">4</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">5</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">6</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">8</td>
+        <th scope="row"><strong>Number of Hearts</strong></th>
+        <td>N/A</td>
+        <td>4</td>
+        <td>5</td>
+        <td>6</td>
+        <td>8</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Top Speed</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">280 m/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">450 m/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">530 m/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">450 m/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">450 m/s</td>
+        <th scope="row"><strong>Top Speed</strong></th>
+        <td>280 m/s</td>
+        <td>450 m/s</td>
+        <td>530 m/s</td>
+        <td>450 m/s</td>
+        <td>450 m/s</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Swarm Size</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">32</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">64</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">96</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">128</td>
+        <th scope="row"><strong>Swarm Size</strong>
+        </th>
+        <td>N/A</td>
+        <td>32</td>
+        <td>64</td>
+        <td>96</td>
+        <td>128</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Enrage timer</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">06:00</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">07:00</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">07:00</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">08:00</td>
+        <th scope="row"><strong>Enrage timer</strong></th>
+        <td>N/A</td>
+        <td>06:00</td>
+        <td>07:00</td>
+        <td>07:00</td>
+        <td>08:00</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Kill reward</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">40,000Cr</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">8,000,000Cr</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">24,000,000Cr</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">40,000,000Cr</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">60,000,000Cr</td>
+        <th scope="row"><strong>Kill reward</strong></th>
+        <td>40,000Cr</td>
+        <td>8,000,000Cr</td>
+        <td>24,000,000Cr</td>
+        <td>40,000,000Cr</td>
+        <td>60,000,000Cr</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Total HP</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">180</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">800</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">1800</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">2500</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">3200</td>
+        <th scope="row"><strong>Total HP</strong></th>
+        <td>180</td>
+        <td>800</td>
+        <td>1800</td>
+        <td>2500</td>
+        <td>3200</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Heart HP</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">38</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">70</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">70</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">140</td>
+        <th scope="row"><strong>Heart HP</strong></th>
+        <td>N/A</td>
+        <td>38</td>
+        <td>70</td>
+        <td>70</td>
+        <td>140</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Armour Rating</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">100</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">140</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">170</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">220</td>
+        <th scope="row"><strong>Armour Rating</strong> </th>
+        <td>N/A</td>
+        <td>100</td>
+        <td>140</td>
+        <td>170</td>
+        <td>220</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Human Weapon Resistance</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">77%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">99.00%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">99.00%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">99.00%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">99.00%</td>
+        <th scope="row"><strong>Human Weapon Resistance</strong></th>
+        <td>77%</td>
+        <td>99.00%</td>
+        <td>99.00%</td>
+        <td>99.00%</td>
+        <td>99.00%</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Passive Regen Speed %/s</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">0.4</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">0.4</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">0.4</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">0.4</td>
+        <th scope="row"><strong>Passive Regen Speed %/s</strong></th>
+        <td>N/A</td>
+        <td>0.4</td>
+        <td>0.4</td>
+        <td>0.4</td>
+        <td>0.4</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Passive Regen Speed HP/s.</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">3.2</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">7.2</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">10</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">12.8</td>
+        <th scope="row"><strong>Passive Regen Speed HP/s.</strong></th>
+        <td>N/A</td>
+        <td>3.2</td>
+        <td>7.2</td>
+        <td>10</td>
+        <td>12.8</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Exerted Hull Regen Speed</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
+        <th scope="row"><strong>Exerted Hull Regen Speed</strong></th>
+        <td>N/A</td>
+        <td>&nbsp;</td>
+        <td>&nbsp;</td>
+        <td>&nbsp;</td>
+        <td>&nbsp;</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Shield Strength</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">2450</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">4300</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">6150</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">8000</td>
+        <th scope="row"><strong>Shield Strength</strong></th>
+        <td>N/A</td>
+        <td>2450</td>
+        <td>4300</td>
+        <td>6150</td>
+        <td>8000</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Shield Decay Rate</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">25 Mj/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">25 Mj/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">25 Mj/s</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">25 Mj/s</td>
+        <th scope="row"></strong>Shield Decay Rate</strong></th>
+        <td>N/A</td>
+        <td>25 Mj/s</td>
+        <td>25 Mj/s</td>
+        <td>25 Mj/s</td>
+        <td>25 Mj/s</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Shield Decay Time (100% to 0%)</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">01:38</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">02:51</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">04:05</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">05:19</td>
+        <th scope="row"><strong>Shield Decay Time (100% to 0%)</strong></th>
+        <td>N/A</td>
+        <td>01:38</td>
+        <td>02:51</td>
+        <td>04:05</td>
+        <td>05:19</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Cannon Volley Size</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">3</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">4</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">8</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">12</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">12</td>
+        <th scope="row"><strong>Cannon Volley Size</strong></th>
+        <td>3</td>
+        <td>4</td>
+        <td>8</td>
+        <td>12</td>
+        <td>12</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Cannon Range</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">~3km</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">~3km</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">~3km</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">~3km</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">~3km</td>
+        <th scope="row"><strong>Cannon Range</strong></th>
+        <td>~3km</td>
+        <td>~3km</td>
+        <td>~3km</td>
+        <td>~3km</td>
+        <td>~3km</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Cannon Reload Time</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:10</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:15</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:10</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:05</td>
+        <th scope="row"><strong>Cannon Reload Time</strong></th>
+        <td>N/A</td>
+        <td>00:10</td>
+        <td>00:15</td>
+        <td>00:10</td>
+        <td>00:05</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Attack Run Duration</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈0:30</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈0:26</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈0:26</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈0:20</td>
+        <th scope="row"><strong>Attack Run Duration</strong></th>
+        <td>N/A</td>
+        <td>≈0:30</td>
+        <td>≈0:26</td>
+        <td>≈0:26</td>
+        <td>≈0:20</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Raw Damage per Volley</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">20 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">68 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">132 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">163 (CAU)</td>
+        <th scope="row"><strong>Raw Damage per Volley</strong></th>
+        <td>N/A</td>
+        <td>20 (CAU)</td>
+        <td>68 (CAU)</td>
+        <td>132 (CAU)</td>
+        <td>163 (CAU)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Shield Damage Per Volley§</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈8 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈28 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈53 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈65 (CAU)</td>
+        <th scope="row"><strong>Shield Damage Per Volley§</strong></th>
+        <td>N/A</td>
+        <td>≈8 (CAU)</td>
+        <td>≈28 (CAU)</td>
+        <td>≈53 (CAU)</td>
+        <td>≈65 (CAU)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Phasing Hull Damage Per Volley</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈1 (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈4 (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈12 (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈12 (ABS)</td>
+        <th scope="row"><strong>Phasing Hull Damage Per Volley</strong></td>
+        <td>N/A</td>
+        <td>≈1 (ABS)</td>
+        <td>≈4 (ABS)</td>
+        <td>≈12 (ABS)</td>
+        <td>≈12 (ABS)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Direct Hull Damage Per Volley†</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">20 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">68 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">132 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">163 (CAU)</td>
+        <th scope="row"><strong>Direct Hull Damage Per Volley†</strong></th>
+        <td>N/A</td>
+        <td>20 (CAU)</td>
+        <td>68 (CAU)</td>
+        <td>132 (CAU)</td>
+        <td>163 (CAU)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Volleys per Attack Run</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈20 Volleys</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈20 Volleys</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈18 Volleys</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈13 Volleys</td>
+        <th scope="row"><strong>Volleys per Attack Run</strong></th>
+        <td>N/A</td>
+        <td>≈20 Volleys</td>
+        <td>≈20 Volleys</td>
+        <td>≈18 Volleys</td>
+        <td>≈13 Volleys</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Shield Damage Per Attack Run§</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈160 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈560 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈954 (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈854 (CAU)</td>
+        <th scope="row"><strong>Shield Damage Per Attack Run§</strong></th>
+        <td>N/A</td>
+        <td>≈160 (CAU)</td>
+        <td>≈560 (CAU)</td>
+        <td>≈954 (CAU)</td>
+        <td>≈854 (CAU)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Direct Hull Damage Per Attack Run†</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">400</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">1360</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">2376</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">2119</td>
+        <th scope="row"><strong>Direct Hull Damage Per Attack Run†</strong></th>
+        <td>N/A</td>
+        <td>400</td>
+        <td>1360</td>
+        <td>2376</td>
+        <td>2119</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Phasing Hull Damage Per Attack Run</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈20 (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈80 (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈216 (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈156 (ABS)</td>
+        <th scope="row"><strong>Phasing Hull Damage Per Attack Run</strong></th>
+        <td>N/A</td>
+        <td>≈20 (ABS)</td>
+        <td>≈80 (ABS)</td>
+        <td>≈216 (ABS)</td>
+        <td>≈156 (ABS)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Cannon DPS (Shield)§</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈5/s (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈19/s (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈35/s (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈43/s (CAU)</td>
+        <th scope="row"><strong>Cannon DPS (Shield)§</strong></th>
+        <td>N/A</td>
+        <td>≈5/s (CAU)</td>
+        <td>≈19/s (CAU)</td>
+        <td>≈35/s (CAU)</td>
+        <td>≈43/s (CAU)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Cannon DPS (Direct Hull)†</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈13/s (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈45/s (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈88/s (CAU)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈109/s (CAU)</td>
+        <th scope="row"><strong>Cannon DPS (Direct Hull)†</strong></th>
+        <td>N/A</td>
+        <td>≈13/s (CAU)</td>
+        <td>≈45/s (CAU)</td>
+        <td>≈88/s (CAU)</td>
+        <td>≈109/s (CAU)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Cannon DPS (Phasing Hull)</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈0.7/s (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈2.7/s (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈8/s (ABS)</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">≈8/s (ABS)</td>
+        <th scope="row"><strong>Cannon DPS (Phasing Hull)</strong></th>
+        <td>N/A</td>
+        <td>≈0.7/s (ABS)</td>
+        <td>≈2.7/s (ABS)</td>
+        <td>≈8/s (ABS)</td>
+        <td>≈8/s (ABS)</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Lightning Duration</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:08</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:10</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:12</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">00:14</td>
+        <th scope="row"><strong>Lightning Duration</strong></th>
+        <td>N/A</td>
+        <td>00:08</td>
+        <td>00:10</td>
+        <td>00:12</td>
+        <td>00:14</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Lightning Damage</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;vertical-align:top;">&nbsp;</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">800</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">1700</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">2800</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">4400</td>
+        <th scope="row"><strong>Lightning Damage</strong></th>
+        <td>N/A</td>
+        <td>800</td>
+        <td>1700</td>
+        <td>2800</td>
+        <td>4400</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Damage to exert the first heart</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">160</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">360</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">500</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">640</td>
+        <th scope="row"><strong>Damage to exert the first heart</strong></td>
+        <td>N/A</td>
+        <td>160</td>
+        <td>360</td>
+        <td>500</td>
+        <td>640</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Optimal Medium Gauss&nbsp;</strong><br><strong>Shots to Exert First Heart</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">6</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">12</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">24</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">44</td>
+        <th scope="row"><strong>Optimal Medium Gauss&nbsp;</strong><br><strong>Shots to Exert First Heart</strong></th>
+        <td>N/A</td>
+        <td>6</td>
+        <td>12</td>
+        <td>24</td>
+        <td>44</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Optimal Medium Gauss&nbsp;</strong><br><strong>Shots to Destroy a Heart</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">3</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">4</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">5</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">13</td>
+        <th scope="row"><strong>Optimal Medium Gauss&nbsp;<br>Shots to Destroy a Heart</strong></th><td>N/A</td>
+        <td>3</td>
+        <td>4</td>
+        <td>5</td>
+        <td>13</td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Hull Damage % required to Exert</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">Heart 1: 20%&nbsp;<br>Heart 2: 16%&nbsp;<br>Heart 3: 12%&nbsp;<br>Heart 4: 8%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">Heart 1: 20%<br>Heart 2: 16%<br>Heart 3: 14%<br>Heart 4: 10%<br>Heart 5: 8%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">Heart 1: 20%&nbsp;<br>Heart 2: 17%&nbsp;<br>Heart 3: 15%<br>Heart 4: 12%<br>Heart 5: 10%<br>Heart 6: 7%</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">Heart 1: 20%<br>Heart 2: 18%<br>Heart 3: 16%<br>Heart 4: 14%<br>Heart 5: 12%<br>Heart 6: 10%<br>Heart 7: 8%<br>Heart 8: 6%</td>
+        <th scope="row"><strong>Hull Damage % required to Exert</strong></th>
+        <td>N/A</td>
+        <td>Heart 1: 20%&nbsp;<br>Heart 2: 16%&nbsp;<br>Heart 3: 12%&nbsp;<br>Heart 4: 8%
+        </td>
+        <td>Heart 1: 20%<br>Heart 2: 16%<br>Heart 3: 14%<br>Heart 4: 10%<br>Heart 5: 8%
+        </td>
+        <td>Heart 1: 20%&nbsp;<br>Heart 2: 17%&nbsp;<br>Heart 3: 15%<br>Heart 4: 12%<br>Heart 5: 10%<br>Heart 6: 7%
+        </td>
+        <td>Heart 1: 20%<br>Heart 2: 18%<br>Heart 3: 16%<br>Heart 4: 14%<br>Heart 5: 12%<br>Heart 6: 10%<br>Heart 7: 8%<br>Heart 8: 6%
+        </td>
       </tr>
       <tr>
-        <td style="background-color:hsl(0, 0%, 30%);border-bottom:1px solid #000000;border-left:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;"><strong>Heart exertion thresholds</strong><br><strong>In % of current max Hull</strong></td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">N/A</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">80</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">80</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">80</td>
-        <td style="border-bottom:1px solid #000000;border-right:1px solid #000000;padding:2px 3px;text-align:center;vertical-align:top;">80</td>
+        <th scope="row"><strong>Heart exertion thresholds</strong><br><strong>In % of current max Hull</strong></th>
+        <td>N/A</td>
+        <td>80</td>
+        <td>80</td>
+        <td>80</td>
+        <td>80</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION

Fixes #15 
I have removed all CSS styling from thargoid-specs.html,  and moved them into a CSS file called thargoid-specs.css.

The CSS uses elements to decide the styling, and then the square brackets are for attributes.

There are also some changes to the structure of the html to increase the readability of the code.